### PR TITLE
Update Gallery styling

### DIFF
--- a/SampleGallery/App.xaml
+++ b/SampleGallery/App.xaml
@@ -21,6 +21,7 @@
             <SolidColorBrush x:Key="LightThemeBackgroundColorBrush" Color="White" />
             <SolidColorBrush x:Key="MainNavigationForegroundColor" Color="#666666" />
             <SolidColorBrush x:Key="MainNavigationSelectedForegroundColor" Color="#00BCF2" />
+            <SolidColorBrush x:Key="CustomThemeSecondarySolidColor" Color="#00B2F0"/>
 
             <AcrylicBrush x:Key="CustomTitleBarAcrylic"
                           BackgroundSource="HostBackdrop"
@@ -31,13 +32,17 @@
                           BackgroundSource="Backdrop"
                           TintColor="#00B2F0" TintOpacity="0.7" />
             
-            <!--Override navview style keys-->
-            <AcrylicBrush x:Key="NavigationViewDefaultPaneBackground"
+            <!--Override navview style keys; with fallbacks on some keys for acrylic if api not present-->
+            <contractPresent:AcrylicBrush x:Key="NavigationViewDefaultPaneBackground"
                                    BackgroundSource="Backdrop"
                                    TintOpacity=".6" TintColor="#00B2F0" />
-            <AcrylicBrush x:Key="NavigationViewTopPaneBackground"
+            <contractNotPresent:SolidColorBrush x:Key="NavigationViewDefaultPaneBackground" Color="#00B2F0"/>
+            
+            <contractPresent:AcrylicBrush x:Key="NavigationViewTopPaneBackground"
                             BackgroundSource="Backdrop"
                             TintOpacity=".6" TintColor="#00B2F0" />
+            <contractNotPresent:SolidColorBrush x:Key="NavigationViewTopPaneBackground" Color="#00B2F0"/>
+            
             <local:NavViewXCBB x:Key="NavigationViewExpandedPaneBackground"/>
 
 

--- a/SampleGallery/App.xaml
+++ b/SampleGallery/App.xaml
@@ -23,12 +23,12 @@
             <SolidColorBrush x:Key="MainNavigationSelectedForegroundColor" Color="#00BCF2" />
             <SolidColorBrush x:Key="CustomThemeSecondarySolidColor" Color="#00B2F0"/>
 
-            <AcrylicBrush x:Key="CustomTitleBarAcrylic"
+            <contractPresent:AcrylicBrush x:Key="CustomTitleBarAcrylic"
                           BackgroundSource="HostBackdrop"
                           TintColor="#00B2F0" 
                           TintOpacity="0.7"/>
 
-            <AcrylicBrush x:Key="CustomFeaturedSamplesAcrylic"
+            <contractPresent:AcrylicBrush x:Key="CustomFeaturedSamplesAcrylic"
                           BackgroundSource="Backdrop"
                           TintColor="#00B2F0" TintOpacity="0.7" />
             

--- a/SampleGallery/App.xaml
+++ b/SampleGallery/App.xaml
@@ -19,9 +19,28 @@
             <SolidColorBrush x:Key="DarkThemeForeground" Color="#363636" />
             <SolidColorBrush x:Key="DarkThemeForegroundPointerOver" Color="#3F3F3F" />
             <SolidColorBrush x:Key="LightThemeBackgroundColorBrush" Color="White" />
-            <SolidColorBrush x:Key="CategoryPageFeaturedSamplesBackground" Color="Azure" />
             <SolidColorBrush x:Key="MainNavigationForegroundColor" Color="#666666" />
             <SolidColorBrush x:Key="MainNavigationSelectedForegroundColor" Color="#00BCF2" />
+
+            <AcrylicBrush x:Key="CustomTitleBarAcrylic"
+                          BackgroundSource="HostBackdrop"
+                          TintColor="#00B2F0" 
+                          TintOpacity="0.7"/>
+
+            <AcrylicBrush x:Key="CustomFeaturedSamplesAcrylic"
+                          BackgroundSource="Backdrop"
+                          TintColor="#00B2F0" TintOpacity="0.7" />
+            
+            <!--Override navview style keys-->
+            <AcrylicBrush x:Key="NavigationViewDefaultPaneBackground"
+                                   BackgroundSource="Backdrop"
+                                   TintOpacity=".6" TintColor="#00B2F0" />
+            <AcrylicBrush x:Key="NavigationViewTopPaneBackground"
+                            BackgroundSource="Backdrop"
+                            TintOpacity=".6" TintColor="#00B2F0" />
+            <local:NavViewXCBB x:Key="NavigationViewExpandedPaneBackground"/>
+
+
             <!-- SplitViewTogglePaneButtonTemplate -->
             <ControlTemplate x:Key="SplitViewTogglePaneButtonTemplate" TargetType="Button">
                 <Grid x:Name="RootGrid" Background="{TemplateBinding Background}" Width="{StaticResource BackButtonWidth}" Height="{StaticResource BackButtonWidth}">

--- a/SampleGallery/MainPage.xaml.cs
+++ b/SampleGallery/MainPage.xaml.cs
@@ -90,7 +90,7 @@ namespace CompositionSampleGallery
 
                 // Apply acrylic to the main navigation
                 TitleBarRow.Height = new GridLength(31);
-                TitleBarGrid.Background = (Brush)Application.Current.Resources["SystemControlChromeMediumLowAcrylicWindowMediumBrush"];
+                TitleBarGrid.Background = (Brush)Application.Current.Resources["CustomTitleBarAcrylic"];
             }
 #endif
         }

--- a/SampleGallery/NavViewXCBB.cs
+++ b/SampleGallery/NavViewXCBB.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI;
+﻿using Windows.Foundation.Metadata;
+using Windows.UI;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
@@ -13,13 +14,23 @@ namespace CompositionSampleGallery
         {
             Compositor compositor = Window.Current.Compositor;
 
-            var brush = compositor.CreateLinearGradientBrush();
-            var colorStop1 = compositor.CreateColorGradientStop(0.0f, Color.FromArgb((byte)(255*0.7), 0, 178, 240));  // Match color to hex used by FeaturedSamples and titlebar
-            var colorStop2 = compositor.CreateColorGradientStop(0.8f, Colors.White);
+            // Use LBG if Api contract exists 
+            var customBlue = Color.FromArgb((byte)(255 * 0.7), 0, 178, 240);  // Match color to hex used by FeaturedSamples and titlebar
+            CompositionBrush brush;
+            if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 5))
+            {
+                brush = compositor.CreateLinearGradientBrush();
+                var colorStop1 = compositor.CreateColorGradientStop(0.0f, customBlue); 
+                var colorStop2 = compositor.CreateColorGradientStop(0.8f, Colors.White);
 
-            brush.ColorStops.Add(colorStop1);
-            brush.ColorStops.Add(colorStop2);
-
+                ((CompositionLinearGradientBrush)brush).ColorStops.Add(colorStop1);
+                ((CompositionLinearGradientBrush)brush).ColorStops.Add(colorStop2);
+            }
+            else
+            {
+                brush = compositor.CreateColorBrush(customBlue);
+            }
+            
             CompositionBrush = brush;
         }
 

--- a/SampleGallery/NavViewXCBB.cs
+++ b/SampleGallery/NavViewXCBB.cs
@@ -1,0 +1,35 @@
+﻿using Windows.UI;
+using Windows.UI.Composition;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+
+namespace CompositionSampleGallery
+{
+    class NavViewXCBB : XamlCompositionBrushBase
+    {
+        public NavViewXCBB() { }
+
+        protected override void OnConnected()
+        {
+            Compositor compositor = Window.Current.Compositor;
+
+            var brush = compositor.CreateLinearGradientBrush();
+            var colorStop1 = compositor.CreateColorGradientStop(0.0f, Color.FromArgb((byte)(255*0.7), 0, 178, 240));  // Match color to hex used by FeaturedSamples and titlebar
+            var colorStop2 = compositor.CreateColorGradientStop(0.8f, Colors.White);
+
+            brush.ColorStops.Add(colorStop1);
+            brush.ColorStops.Add(colorStop2);
+
+            CompositionBrush = brush;
+        }
+
+        protected override void OnDisconnected()
+        {
+            if (CompositionBrush != null)
+            {
+                CompositionBrush.Dispose();
+            }
+        }
+
+    }
+}

--- a/SampleGallery/Pages/BaseCategoryPage.xaml
+++ b/SampleGallery/Pages/BaseCategoryPage.xaml
@@ -44,7 +44,6 @@
             <local:FeaturedSamples 
                 x:Name="FeaturedSampleControl" 
                 Description="Click a sample to learn more"
-                Background="{StaticResource CustomFeaturedSamplesAcrylic}"
                 Foreground="Black"/>
             <!-- End featured transition samples -->
         </GridView.Header>

--- a/SampleGallery/Pages/BaseCategoryPage.xaml
+++ b/SampleGallery/Pages/BaseCategoryPage.xaml
@@ -7,10 +7,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     d:DesignHeight="300"
-    d:DesignWidth="400">
+    d:DesignWidth="400"
+    Loaded="Page_Loaded">
 
-    <Grid x:Name="MainGrid">
-
+    <GridView x:Name="MainGrid">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup>
 
@@ -21,7 +21,7 @@
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="CategoryDescriptionTextBlock.Style" Value="{StaticResource CategoryDescriptionTextBlockStyleWide}" />
-                        <Setter Target="MainGrid.Background" Value="White" />
+
                     </VisualState.Setters>
                 </VisualState>
 
@@ -32,36 +32,37 @@
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="CategoryDescriptionTextBlock.Style" Value="{StaticResource CategoryDescriptionTextBlockStyleNarrow}" />
-                        <Setter Target="MainGrid.Background" Value="Black" />
+           
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
             
         </VisualStateManager.VisualStateGroups>
-        <ScrollViewer HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Disabled">
 
-            <StackPanel>
-                <!-- Featured transition samples -->
-                <local:FeaturedSamples 
-                    x:Name="FeaturedSampleControl" 
-                    Description="Click a sample to learn more"
-                    Background="{StaticResource CategoryPageFeaturedSamplesBackground}"
-                    Foreground="Black"/>
-                <!-- End featured transition samples -->
+        <GridView.Header>
+            <!-- Featured transition samples -->
+            <local:FeaturedSamples 
+                x:Name="FeaturedSampleControl" 
+                Description="Click a sample to learn more"
+                Background="{StaticResource CustomFeaturedSamplesAcrylic}"
+                Foreground="Black"/>
+            <!-- End featured transition samples -->
+        </GridView.Header>
 
-                <RichTextBlock x:Name="CategoryDescriptionTextBlock" Style="{StaticResource CategoryDescriptionTextBlockStyleWide}" />
+        <StackPanel>
+            <RichTextBlock x:Name="CategoryDescriptionTextBlock" Style="{StaticResource CategoryDescriptionTextBlockStyleWide}" />
 
-                <!-- Samples list -->
-                <local:BodyAppList
-                    x:Name="FullSampleList" />
-                <!-- End samples list -->
+            <!-- Samples list -->
+            <local:BodyAppList
+                x:Name="FullSampleList" />
+            <!-- End samples list -->
 
-                <!-- Footer -->
-                <local:Social Margin="0,50,0,0" />
-                <!-- End footer -->
+            <!-- Footer -->
+            <local:Social Margin="0,50,0,0" />
+            <!-- End footer -->
 
-            </StackPanel>
-            
-        </ScrollViewer>
-    </Grid>
+
+        </StackPanel>
+
+    </GridView>
 </Page>

--- a/SampleGallery/SampleGallery.csproj
+++ b/SampleGallery/SampleGallery.csproj
@@ -256,6 +256,7 @@
       <DependentUpon>FeaturedSamples.xaml</DependentUpon>
     </Compile>
     <Compile Include="Shared\MainNavigationViewModel.cs" />
+    <Compile Include="NavViewXCBB.cs" />
     <Compile Include="Shared\SharedResourceDictionaries.xaml.cs">
       <DependentUpon>SharedResourceDictionaries.xaml</DependentUpon>
     </Compile>

--- a/SampleGallery/SampleGalleryNavViewHost.xaml
+++ b/SampleGallery/SampleGalleryNavViewHost.xaml
@@ -16,7 +16,7 @@
             x:Name="NavView"  
             IsSettingsVisible="True"
             ItemInvoked="NavViewItemInvoked">
-
+            
             <Frame x:Name="ContentFrame" Margin="24"/>
                         
         </contract5Present:NavigationView>

--- a/SampleGallery/Shared/FeaturedSamples.xaml
+++ b/SampleGallery/Shared/FeaturedSamples.xaml
@@ -5,6 +5,8 @@
     xmlns:local="using:CompositionSampleGallery"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:contractNotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)"
+    xmlns:contractPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
     xmlns:common="using:SamplesCommon"
     Loaded="UserControl_Loaded"
     mc:Ignorable="d" Background="Transparent">
@@ -23,9 +25,10 @@
     </UserControl.Resources>
 
     <Grid x:Name="MainGrid"       
-         Background="{x:Bind Background}"
+          contractPresent:Background="{StaticResource CustomFeaturedSamplesAcrylic}"
+          contractNotPresent:Background="{StaticResource CustomThemeSecondarySolidColor}" 
           MaxHeight="{x:Bind MaxHeight}" >
-        
+
         <Grid.RowDefinitions>
             <RowDefinition x:Name="Row0" />
             <RowDefinition x:Name="Row1" />

--- a/SampleGallery/Shared/FeaturedSamples.xaml
+++ b/SampleGallery/Shared/FeaturedSamples.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:common="using:SamplesCommon"
     Loaded="UserControl_Loaded"
-    mc:Ignorable="d">
+    mc:Ignorable="d" Background="Transparent">
     <UserControl.Resources>
 
         <ResourceDictionary>
@@ -22,10 +22,11 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Grid x:Name="MainGrid"
-          Background="{x:Bind Background}" 
+    <Grid x:Name="MainGrid"       
+         Background="{x:Bind Background}"
           MaxHeight="{x:Bind MaxHeight}" >
-    <Grid.RowDefinitions>
+        
+        <Grid.RowDefinitions>
             <RowDefinition x:Name="Row0" />
             <RowDefinition x:Name="Row1" />
         </Grid.RowDefinitions>
@@ -76,7 +77,7 @@
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-        <StackPanel x:Name="TextStackPanel" 
+        <StackPanel x:Name="TextStackPanel" Background="Transparent"
                     Grid.Row="0" 
                     Grid.Column="0" 
                     Grid.RowSpan="2"


### PR DESCRIPTION
<!-- Thanks for contributing to WindowsCompositionSamples! Someone from our team will take a look and get back to you as soon as possible. -->

##  Pull Request Type
[ ] Bugfix <!—Please add link to related Issue below -->  
[ ] New Sample  
[X] Other - Please describe:   Gallery update

## Issue
N/A

## Proposed Changes
Recent XAML update removed acrylic from navview when expanded on left.

This commit updates gallery styling to:
* Use custom XCBB for navview (also allows future extensibility)
* Updates primary gallery accent color areas (title, nav, featured
section)
* Update Featured Samples to in-app acrylic sticky header

## Screenshot/GIF (if applicable):
![gif](https://media.giphy.com/media/833FxgBrTIRnkjmJin/giphy.gif)

<img width="770" alt="sgupdate1" src="https://user-images.githubusercontent.com/22989057/50941328-4da71e00-1439-11e9-8b01-3cf3c8f06f7c.PNG">
<img width="600" alt="sgupdate1_2" src="https://user-images.githubusercontent.com/22989057/50941329-4e3fb480-1439-11e9-80f1-c8028fb822e9.PNG">

