### PR TITLE
Fixed topBorderExitAnimation

### DIFF
--- a/SampleGallery/Samples/SDK 15063/NavigationFlow/NavigationFlowDestinationPage.xaml.cs
+++ b/SampleGallery/Samples/SDK 15063/NavigationFlow/NavigationFlowDestinationPage.xaml.cs
@@ -81,7 +81,7 @@ namespace CompositionSampleGallery
             // Add a translation animation that will play when this element exits the scene
             var topBorderExitAnimation = _compositor.CreateScalarKeyFrameAnimation();
             topBorderExitAnimation.Target = "Translation.Y";
-            topBorderExitAnimation.InsertKeyFrame(1, -30);
+            topBorderExitAnimation.InsertKeyFrame(1, -450.0f);
             topBorderExitAnimation.Duration = TimeSpan.FromSeconds(0.4);
 
             ElementCompositionPreview.SetIsTranslationEnabled(TopBorder, true);


### PR DESCRIPTION
topBorderExitAnimation was set to -30.  However, that is the setting for mainContentExitAnimition.  

topBorderOffsetAnimation is set to -450.0f on the show animation (keyframe 0), line 40.  To reverse that animation, -450.0f should be used on the exit animation (keyframe 1), line 84.

The updated setting provides a smoother and more complete top border exit animation.

<!-- Thanks for contributing to WindowsCompositionSamples! Someone from our team will take a look and get back to you as soon as possible. -->

##  Pull Request Type
[ ] Bugfix <!—Please add link to related Issue below -->  
[ ] New Sample  
[ ] Other - Please describe:   

## Issue
<!-- Link to any relevant issues --> #  

## Proposed Changes
-  
-  

## Screenshot/GIF (if applicable):
