### PR TITLE
Remove link button from Video Playground sample

### DIFF
--- a/SampleGallery/Samples/SDK 14393/VideoPlayground/VideoPlayground.xaml
+++ b/SampleGallery/Samples/SDK 14393/VideoPlayground/VideoPlayground.xaml
@@ -113,22 +113,10 @@
                             Margin="10, 10, 25, 10">
                     <!-- Controls to load video. -->
                     <TextBlock Text="Video Source" Style="{StaticResource VideoPlaygroundText}" />
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <Button x:Name="OpenFileButton" 
-                            Content="Open File" 
-                            Style="{StaticResource VideoPlaygroundButton}"
-                            Command="{Binding OpenFileCommand}"/>
-                        <Button x:Name="OpenUriButton" 
-                            Grid.Column="1" 
-                            Content="Open Link" 
-                            Style="{StaticResource VideoPlaygroundButton}"
-                            Command="{Binding OpenLinkDialogCommand}"
-                            CommandParameter="{Binding ElementName=LinkDialog}"/>
-                    </Grid>
+                    <Button x:Name="OpenFileButton" 
+                        Content="Open File" 
+                        Style="{StaticResource VideoPlaygroundButton}"
+                        Command="{Binding OpenFileCommand}"/>
 
                     <!-- The rest of these controls shouldn't show if there is not video loaded, as 
                          there shouldn't be a current effect assigned until then.-->

--- a/SampleGallery/Samples/SDK 14393/VideoPlayground/VideoPlaygroundViewModel.cs
+++ b/SampleGallery/Samples/SDK 14393/VideoPlayground/VideoPlaygroundViewModel.cs
@@ -184,8 +184,6 @@ namespace CompositionSampleGallery
         public IDelegateCommand AddLightCommand { get; private set; } 
         public IDelegateCommand RemoveLightCommand { get; private set; }
         public IDelegateCommand OpenFileCommand { get; private set; }
-        public IDelegateCommand OpenLinkDialogCommand { get; private set; }
-        public IDelegateCommand OpenLinkCommand { get; private set; }
         public IDelegateCommand AnimateCommand { get; private set; }
         #endregion
 
@@ -227,8 +225,6 @@ namespace CompositionSampleGallery
             RemoveLightCommand = new DelegateCommand(RemoveLightButton);
             AnimateCommand = new DelegateCommand(Animate);
             OpenFileCommand = new DelegateCommand(OpenFile);
-            OpenLinkDialogCommand = new DelegateCommand(OpenLinkDialog);
-            OpenLinkCommand = new DelegateCommand(OpenLink);
 
             DurationIndex = 0;
         }
@@ -242,40 +238,6 @@ namespace CompositionSampleGallery
         private void OpenFile(object obj)
         {
             LoadFile();
-        }
-
-        /// <summary>
-        /// Command that shows the given ContentDialog.
-        /// </summary>
-        /// <param name="param">The ContentDialog to show.</param>
-        private async void OpenLinkDialog(object param)
-        {
-            var dialog = param as ContentDialog;
-
-            if (dialog != null)
-            {
-                await dialog.ShowAsync();
-            }
-        }
-
-        /// <summary>
-        /// Command that opens the given link as a MediaSource.
-        /// </summary>
-        /// <param name="param">String that is a valid Uri.</param>
-        private void OpenLink(object param)
-        {
-            try
-            {
-                var link = param as String;
-
-                var source = MediaSource.CreateFromUri(new Uri(link));
-
-                LoadSource(source);
-            }
-            catch(Exception ex)
-            {
-                var ignored = ErrorMessage("Video Error", ex.Message);
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
This addresses issue #336 

Technically this would of taken any valid Uri to a video file... but it's unnecessary given the file picker option.
