### PR TITLE
Fix #361

### DIFF
--- a/SamplesCommon/SamplesCommon/ImageLoader/ImageLoader.cs
+++ b/SamplesCommon/SamplesCommon/ImageLoader/ImageLoader.cs
@@ -152,7 +152,7 @@ namespace SamplesCommon
 
         public ManagedSurface LoadFromUri(Uri uri, Size size)
         {
-            return LoadFromUri(uri, Size.Empty, null);
+            return LoadFromUri(uri, size, null);
         }
 
         public ManagedSurface LoadFromUri(Uri uri, Size size, LoadTimeEffectHandler handler)


### PR DESCRIPTION
This change fixes issue #361 . We never caught this because the other caller pases Size.Empty.